### PR TITLE
Step 1.4: Clone-on-write

### DIFF
--- a/1_concepts/1_4_cow/src/main.rs
+++ b/1_concepts/1_4_cow/src/main.rs
@@ -1,3 +1,14 @@
+use std::{borrow::Cow, env};
+
 fn main() {
-    println!("Implement me!");
+    let path: Cow<'static, str> =
+        if let Some(path) = env::args().skip_while(|p| p != "--conf").nth(1) {
+            path.into()
+        } else if let Ok(path) = env::var("APP_CONF") {
+            path.into()
+        } else {
+            "/etc/app/app.conf".into()
+        };
+
+    println!("{path}");
 }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Do not hesitate to ask your mentor/lead with questions, however you won't receiv
 - [ ] [1. Concepts][Step 1] (2 days, after all sub-steps)
     - [x] [1.1. Default values, cloning and copying][Step 1.1] (1 day)
     - [x] [1.2. Boxing and pinning][Step 1.2] (1 day)
-    - [ ] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
+    - [x] [1.3. Shared ownership and interior mutability][Step 1.3] (1 day)
     - [ ] [1.4. Clone-on-write][Step 1.4] (1 day)
     - [ ] [1.5. Conversions, casting and dereferencing][Step 1.5] (1 day)
     - [ ] [1.6. Static and dynamic dispatch][Step 1.6] (1 day)


### PR DESCRIPTION
Resolves [Step 1.4](https://github.com/h1t/rust-incubator/tree/main/1_concepts/1_4_cow)

## Task
Write a simple program which prints out the path to its configuration file. The path should be detected with the following precedence:
1. default path is `/etc/app/app.conf`;
2. if `APP_CONF` env var is specified (and not empty) then use it with higher priority than default;
3. if `--conf` command line argument is specified (error if empty) then use it with the highest priority.

If neither `APP_CONF` env var nor `--conf` command line argument is specified, then no allocation should happen for path detection.