### PR TITLE
Step 2.4: Abstract type in, concrete type out

### DIFF
--- a/2_idioms/2_4_generic_in_type_out/src/main.rs
+++ b/2_idioms/2_4_generic_in_type_out/src/main.rs
@@ -3,8 +3,8 @@ use std::net::{IpAddr, SocketAddr};
 fn main() {
     println!("Refactor me!");
 
-    let mut err = Error::new("NO_USER".to_string());
-    err.status(404).message("User not found".to_string());
+    let mut err = Error::new("NO_USER");
+    err.status(404).message("User not found");
 }
 
 #[derive(Debug)]
@@ -26,10 +26,11 @@ impl Default for Error {
 }
 
 impl Error {
-    pub fn new(code: String) -> Self {
-        let mut err = Self::default();
-        err.code = code;
-        err
+    pub fn new(code: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            ..Self::default()
+        }
     }
 
     pub fn status(&mut self, s: u16) -> &mut Self {
@@ -37,8 +38,8 @@ impl Error {
         self
     }
 
-    pub fn message(&mut self, m: String) -> &mut Self {
-        self.message = m;
+    pub fn message(&mut self, m: impl Into<String>) -> &mut Self {
+        self.message = m.into();
         self
     }
 }
@@ -47,8 +48,8 @@ impl Error {
 pub struct Server(Option<SocketAddr>);
 
 impl Server {
-    pub fn bind(&mut self, ip: IpAddr, port: u16) {
-        self.0 = Some(SocketAddr::new(ip, port))
+    pub fn bind(&mut self, ip: impl Into<IpAddr>, port: u16) {
+        self.0 = Some(SocketAddr::new(ip.into(), port))
     }
 }
 
@@ -68,7 +69,7 @@ mod server_spec {
             server.bind(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
             assert_eq!(format!("{}", server.0.unwrap()), "127.0.0.1:8080");
 
-            server.bind("::1".parse().unwrap(), 9911);
+            server.bind("::1".parse::<IpAddr>().unwrap(), 9911);
             assert_eq!(format!("{}", server.0.unwrap()), "[::1]:9911");
         }
     }

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Do not hesitate to ask your mentor/lead with questions, however you won't receiv
     - [ ] [2.1. Rich types ensure correctness][Step 2.1] (1 day)
     - [ ] [2.2. Swapping values with `mem::replace`][Step 2.2] (1 day)
     - [ ] [2.3. Bound behavior, not data][Step 2.3] (1 day)
-    - [ ] [2.4. Abstract type in, concrete type out][Step 2.4] (1 day)
+    - [x] [2.4. Abstract type in, concrete type out][Step 2.4] (1 day)
     - [ ] [2.5. Exhaustivity][Step 2.5] (1 day)
     - [ ] [2.6. Sealing][Step 2.6] (1 day)
 - [ ] [3. Common ecosystem][Step 3] (2 days, after all sub-steps)


### PR DESCRIPTION
Resolves [Step 2.4](https://github.com/h1t/rust-incubator/tree/main/2_idioms/2_4_generic_in_type_out)

## Task
Refactor the code contained in [this step's crate](src/main.rs) to make it more efficient, idiomatic, simple and pleasant to use.