### PR TITLE
Step 2.6: Sealing

### DIFF
--- a/2_idioms/2_6_sealing/src/lib.rs
+++ b/2_idioms/2_6_sealing/src/lib.rs
@@ -1,4 +1,15 @@
-pub mod my_error;
+/// ```compile_fail
+/// fn check_seal_trait() {
+///     use step_2_6::my_iterator_ext::private::MyIteratorExt;
+/// }
+/// ```
 pub mod my_iterator_ext;
 
-pub use self::{my_error::MyError, my_iterator_ext::MyIteratorExt};
+/// ```compile_fail
+/// fn check_seal_method(err: impl step_2_6::my_error::MyError) {
+///     let _ = err.type_id(step_2_6::my_error::private::Internal);
+/// }
+/// ```
+pub mod my_error;
+
+pub use self::my_error::MyError;

--- a/2_idioms/2_6_sealing/src/my_error.rs
+++ b/2_idioms/2_6_sealing/src/my_error.rs
@@ -6,6 +6,12 @@ use std::{
     fmt::{Debug, Display},
 };
 
+mod private {
+
+    #[derive(Debug)]
+    pub struct Internal;
+}
+
 /// Basic expectations for error values.
 pub trait MyError: Debug + Display {
     /// The lower-level source of this error, if any.
@@ -67,7 +73,7 @@ pub trait MyError: Debug + Display {
     ///
     /// __This is memory-unsafe to override in user code.__
     #[doc(hidden)]
-    fn type_id(&self) -> TypeId
+    fn type_id(&self, _: private::Internal) -> TypeId
     where
         Self: 'static,
     {

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Do not hesitate to ask your mentor/lead with questions, however you won't receiv
     - [ ] [2.3. Bound behavior, not data][Step 2.3] (1 day)
     - [ ] [2.4. Abstract type in, concrete type out][Step 2.4] (1 day)
     - [ ] [2.5. Exhaustivity][Step 2.5] (1 day)
-    - [ ] [2.6. Sealing][Step 2.6] (1 day)
+    - [x] [2.6. Sealing][Step 2.6] (1 day)
 - [ ] [3. Common ecosystem][Step 3] (2 days, after all sub-steps)
     - [ ] [3.1. Testing and mocking][Step 3.1] (1 day)
     - [ ] [3.2. Declarative and procedural macros][Step 3.2] (1 day)


### PR DESCRIPTION
Resolves [Step 2.6](https://github.com/h1t/rust-incubator/tree/main/2_idioms/2_6_sealing)

## Task
Seal the traits defined in [this step's crate](src/lib.rs) in the following way:
- Make the [`MyIteratorExt` trait](src/my_iterator_ext.rs) fully sealed. Do it manually, using the [`sealed`] crate or a similar one is __not allowed__.
- Make the [`MyError` trait](src/my_error.rs) partially sealed. Only seal the method marked with `#[doc(hidden)]` attribute.
- Sealing should work on both module level (disallowing to implement the sealed trait or the sealed method in the root module of the crate or any other module outside the one where the traits are defined, prove it by providing commented implementations in the root module of the crate, which doesn't compile due to the seal, if uncommented) and crate level (prove it by creating [documentation tests which doesn't compile][12] due to the seal).
